### PR TITLE
Enhance the retrieval of the first available bluetooth device

### DIFF
--- a/src/hci-ble.c
+++ b/src/hci-ble.c
@@ -111,6 +111,11 @@ int main(int argc, const char* argv[])
   if (hciDeviceIdOverride != NULL) {
     hciDeviceId = atoi(hciDeviceIdOverride);
   }
+  else
+  {
+		// if no env variable given, use the first available device
+		hciDeviceId = hci_get_route(NULL);
+  }
 
   // setup HCI socket
   hciSocket = hci_open_dev(hciDeviceId);


### PR DESCRIPTION
Hi Sandeep,

First, thanks for your great works which helps me a lot. I've found some problems while using it so I made a fork and fix a bunch of them until all works correctly for my project. Now, I would like to suggest you to add them back into the main project.

Here is my first proposition :

While reading Bluetooth Essentials for Programmers, I found this interesting note :

"Usually, there is only one adapter or it doesn’t matter which one is used, so passing NULL to hci_get_route() will retrieve the resource number of the first available Bluetooth adapter
[...]
Note: Although tempting, it is not a good idea to hard-code the device number 0, because that is not always the ID of the first adapter. For example, if there were two adapters on the system and the first adapter (ID 0) is disabled, then the first available adapter is the one with ID 1."

-> source : http://read.pudn.com/downloads166/ebook/757380/bluetooth_essentials_for_programmers.4272206415.pdf page 70-71

So here is a small patch to add this to bleno.

Thanks in advance,
Regards

Fred

PS: next pull requests will be shorter, I promise ;)
