### PR TITLE
Fix the advertisement restart in linux c lib

### DIFF
--- a/src/hci-ble.c
+++ b/src/hci-ble.c
@@ -168,11 +168,13 @@ int main(int argc, const char* argv[])
         hci_le_set_advertise_enable(hciSocket, 0, 1000);
       } else if (SIGUSR1 == lastSignal) {
         // restart advertising
-        hci_le_set_advertise_enable(hciSocket, 1, 1000);
+        hci_le_set_advertise_enable(hciSocket, 0, 1000);
 
         // set advertisement and scan data
         hci_le_set_advertising_data(hciSocket, (uint8_t*)&advertisementDataBuf, advertisementDataLen, 1000);
         hci_le_set_scan_response_data(hciSocket, (uint8_t*)&scanDataBuf, scanDataLen, 1000);
+
+        hci_le_set_advertise_enable(hciSocket, 1, 1000);
       } 
     } else if (selectRetval) {
       if (FD_ISSET(0, &rfds)) {
@@ -209,10 +211,6 @@ int main(int argc, const char* argv[])
 
         // start advertising
         hci_le_set_advertise_enable(hciSocket, 1, 1000);
-
-        // set advertisement data
-        hci_le_set_advertising_data(hciSocket, (uint8_t*)&advertisementDataBuf, advertisementDataLen, 1000);
-        hci_le_set_scan_response_data(hciSocket, (uint8_t*)&scanDataBuf, scanDataLen, 1000);
       }
     }
   }


### PR DESCRIPTION
Hi Sandeep,

Here is a new proposition :

When dealing with SIGUSR1 the data was set while the advertising was reset to 'on' instead of 'off'

When new advertising data were received, the data was set two times, the latter being done after the advertising was enabled

... or maybe I missed something ;)
