### PR TITLE
Enhance the advertisement data

### DIFF
--- a/lib/linux/hci-ble.js
+++ b/lib/linux/hci-ble.js
@@ -98,9 +98,9 @@ HciBle.prototype.startAdvertising = function(name, serviceUuids) {
   var advertisementData = new Buffer(advertisementDataLength);
 
   // flags
-  advertisementData[i++] = 2;
-  advertisementData[i++] = 0x01;
-  advertisementData[i++] = 0x05;
+  advertisementData[i++] = 2; // Size 
+  advertisementData[i++] = 0x01; // Flags AD Type
+  advertisementData[i++] = 0x05; // 0: LE Limited Discoverable Mode & 2: BR/EDR Not Supported
 
   i = 0;
   var scanData = new Buffer(scanDataLength);
@@ -135,6 +135,8 @@ HciBle.prototype.startAdvertising = function(name, serviceUuids) {
       }
     }
   }
+
+	advertisementData = Buffer.concat ([advertisementData, scanData], advertisementDataLength + scanDataLength);
 
   this.startAdvertisingWithEIRData(advertisementData, scanData);
 };


### PR DESCRIPTION
Hi Sandeep,

Here is my last proposition. 

When scanning a bleno peripheral using some app like lightBlue on iOS, the description of my peripheral wasn't complete. It didn't display the localName and the advertised services. In my iOS code, I also wasn't able to scan for my advertised services using CoreBluetooth API. 

So I try to add the local name and service UUIDs to the advertisement data in addition with in the scan response data and it make all works like a charm.

I also add some comment to clarify the flags ;)

Regards,

Fred
