### PR TITLE
Fixes #78 Allows custom Generic Access/Attribute Service

### DIFF
--- a/lib/linux/l2cap-ble.js
+++ b/lib/linux/l2cap-ble.js
@@ -135,8 +135,24 @@ L2capBle.prototype.onStderrData = function(data) {
 
 L2capBle.prototype.setServices = function(services) {
   // base services and characteristics
-  var allServices = [
-    {
+  var genericAccessServiceExists    = false,
+      genericAttributeServiceExists = false,
+      allServices                   = [],
+      index;
+
+  for (index in services) {
+    if ('1800' == services[index].uuid) {
+      genericAccessServiceExists = true;
+      allServices[0] = services.splice(index, 1);
+    }
+    if ('1801' == services[index].uuid) {
+      genericAttributeServiceExists = true;
+      allServices[1] = services.splice(index, 1);
+    }
+  }
+
+  if (! genericAccessServiceExists) {
+    allServices[0] = {
       uuid: '1800',
       characteristics: [
         {
@@ -154,8 +170,17 @@ L2capBle.prototype.setServices = function(services) {
           descriptors: []
         }
       ]
-    }
-  ].concat(services);
+    };
+  }
+
+  if (! genericAttributeServiceExists) {
+    allServices[1] = {
+      uuid: '1801',
+      characteristics: []
+    };
+  }
+
+  allServices.concat(services);
 
   this._handles = [];
 

--- a/lib/linux/l2cap-ble.js
+++ b/lib/linux/l2cap-ble.js
@@ -143,11 +143,11 @@ L2capBle.prototype.setServices = function(services) {
   for (index in services) {
     if ('1800' == services[index].uuid) {
       genericAccessServiceExists = true;
-      allServices[0] = services.splice(index, 1);
+      allServices[0] = services.splice(index, 1)[0];
     }
     if ('1801' == services[index].uuid) {
       genericAttributeServiceExists = true;
-      allServices[1] = services.splice(index, 1);
+      allServices[1] = services.splice(index, 1)[0];
     }
   }
 

--- a/lib/linux/l2cap-ble.js
+++ b/lib/linux/l2cap-ble.js
@@ -180,7 +180,7 @@ L2capBle.prototype.setServices = function(services) {
     };
   }
 
-  allServices.concat(services);
+  allServices = allServices.concat(services);
 
   this._handles = [];
 

--- a/lib/mac/bindings.js
+++ b/lib/mac/bindings.js
@@ -125,6 +125,57 @@ blenoBindings.setServices = function(services) {
   this.sendCBMsg(12, null); // remove all services
 
   services = services || [];
+
+  // ensure genericAccessService and genericAttributeService exists
+  var genericAccessServiceExists    = false,
+      genericAttributeServiceExists = false,
+      allServices                   = [],
+      index;
+
+  for (index in services) {
+    if ('1800' == services[index].uuid) {
+      genericAccessServiceExists = true;
+      allServices[0] = services.splice(index, 1);
+    }
+    if ('1801' == services[index].uuid) {
+      genericAttributeServiceExists = true;
+      allServices[1] = services.splice(index, 1);
+    }
+  }
+
+  if (! genericAccessServiceExists) {
+    allServices[0] = {
+      uuid: '1800',
+      characteristics: [
+        {
+          uuid: '2a00',
+          properties: ['read'],
+          secure: [],
+          value: new Buffer(os.hostname()),
+          descriptors: []
+        },
+        {
+          uuid: '2a01',
+          properties: ['read'],
+          secure: [],
+          value: new Buffer([0x80, 0x00]),
+          descriptors: []
+        }
+      ]
+    };
+  }
+
+  if (! genericAttributeServiceExists) {
+    allServices[1] = {
+      uuid: '1801',
+      characteristics: []
+    };
+  }
+
+  // after genericAccessService/genericAttributeService house-keeping, merge
+  // allServices with services and process all services uniformly.
+  services = allServices.concat(services);
+
   var attributeId = 1;
 
   this._attributes = [];


### PR DESCRIPTION
Allows one to provide a custom "Generic Access Service" and "Generic Attribute Service" by passing them in with the other services in bleno.setServices([...]).  If not provided, continue to generate them on the fly.