### PR TITLE
Bluez package name update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ __Note:__ Mac OS X, Linux, and Windows are currently the only supported OSes.
 #### Ubuntu/Debian/Raspbian
 
 ```sh
-sudo apt-get install bluetooth bluez-utils libbluetooth-dev libudev-dev
+sudo apt-get install bluetooth bluez libbluetooth-dev libudev-dev
 ```
 
 Make sure ```node``` is on your path, if it's not, some options:


### PR DESCRIPTION
When I run `sudo apt-get install bluez-utils` here is the response:

```
Package bluez-utils is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  bluez

E: Package 'bluez-utils' has no installation candidate
```

Should the `bluez-utils` package now be `bluez`?