### PR TITLE
Add support for Android OS

### DIFF
--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -16,7 +16,7 @@ var platform = os.platform();
 
 if (platform === 'darwin') {
   bindings = require('./mac/bindings');
-} else if (platform === 'linux' || platform === 'win32') {
+} else if (platform === 'linux' || platform === 'win32' || platform === 'android') {
   bindings = require('./hci-socket/bindings');
 } else {
   throw new Error('Unsupported platform');

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "os": [
     "darwin",
     "linux",
+    "android",
     "win32"
   ],
   "scripts": {


### PR DESCRIPTION
Add android to supported OSes, so that bleno can run on Android too.

Signed-off-by: Robert Chiras <robert.chiras@intel.com>