### PR TITLE
Parse advertising interval as float

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -261,7 +261,7 @@ Hci.prototype.setAdvertisingParameters = function() {
   // length
   cmd.writeUInt8(15, 3);
 
-  var advertisementInterval = Math.floor((process.env.BLENO_ADVERTISING_INTERVAL ? parseInt(process.env.BLENO_ADVERTISING_INTERVAL) : 100) * 1.6);
+  var advertisementInterval = Math.floor((process.env.BLENO_ADVERTISING_INTERVAL ? parseFloat(process.env.BLENO_ADVERTISING_INTERVAL) : 100) * 1.6);
 
   // data
   cmd.writeUInt16LE(advertisementInterval, 4); // min interval


### PR DESCRIPTION
Parse `env.BLENO_ADVERTISING_INTERVAL` as a float, allowing users to better control the min/max advertisement interval sent in the `LE_SET_ADVERTISING_PARAMETERS_CMD` HCI packet. The `math.floor` call will still ensure that values sent in the HCI packet are ints.

For some reason I don't understand, Apple [recommends several specific advertising intervals](https://developer.apple.com/library/content/qa/qa1931/_index.html). Most of these intervals are floats, which become nice round ints after being multiplied by 1.6.