### PR TITLE
Limit MTU to 23 for Intel devices

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -121,6 +121,11 @@ BlenoBindings.prototype.onAddressChange = function(address) {
 };
 
 BlenoBindings.prototype.onReadLocalVersion = function(hciVer, hciRev, lmpVer, manufacturer, lmpSubVer) {
+  if (manufacturer === 2) {
+    // Intel Corporation
+    this._gatt.maxMtu = 23; 
+  }
+  
   if (manufacturer === 93) {
     // Realtek Semiconductor Corporation
     this._gatt.maxMtu = 23;


### PR DESCRIPTION
Intel 7260 does not seem to like MTU's higher than 23, making services and characteristics undiscoverable on devices such as iPhones. See Issue #240 for more information.