### PR TITLE
Add FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals.
 
 Need a BLE central module? See [noble](https://github.com/sandeepmistry/noble).
 
-__Note:__ Mac OS X, Linux, and Windows are currently the only supported OSes.
+__Note:__ macOS / Mac OS X, Linux, FreeBSD and Windows are currently the only supported OSes.
 
 ## Prerequisites
 
@@ -49,6 +49,24 @@ sudo yum install bluez bluez-libs bluez-libs-devel
 #### Intel Edison
 
 See [Configure Intel Edison for Bluetooth LE (Smart) Development](http://rexstjohn.com/configure-intel-edison-for-bluetooth-le-smart-development/)
+
+### FreeBSD
+
+Make sure you have GNU Make:
+
+```sh
+sudo pkg install gmake
+```
+
+Disable automatic loading of the default Bluetooth stack by putting [no-ubt.conf](https://gist.github.com/myfreeweb/44f4f3e791a057bc4f3619a166a03b87) into ```/usr/local/etc/devd/no-ubt.conf``` and restarting devd (```sudo service devd restart```).
+
+Unload ```ng_ubt``` kernel module if already loaded:
+
+```sh
+sudo kldunload ng_ubt
+```
+
+Make sure you have read and write permissions on the ```/dev/usb/*``` device that corresponds to your Bluetooth adapter.
 
 ### Windows
 

--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -16,7 +16,7 @@ var platform = os.platform();
 
 if (platform === 'darwin') {
   bindings = require('./mac/bindings');
-} else if (platform === 'linux' || platform === 'win32' || platform === 'android') {
+} else if (platform === 'linux' || platform === 'freebsd' || platform === 'win32' || platform === 'android') {
   bindings = require('./hci-socket/bindings');
 } else {
   throw new Error('Unsupported platform');

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "darwin",
     "linux",
     "android",
+    "freebsd",
     "win32"
   ],
   "scripts": {


### PR DESCRIPTION
Depends on sandeepmistry/node-bluetooth-hci-socket#48.

Tested on: FreeBSD/arm 11.0-STABLE + CSR8510 A10.