### PR TITLE
Adding TypeScript definition

### DIFF
--- a/examples/echo-typescript/characteristic.ts
+++ b/examples/echo-typescript/characteristic.ts
@@ -1,0 +1,48 @@
+import { Characteristic } from '../..';
+
+export class EchoCharacteristic extends Characteristic {
+  _value: any;
+  _updateValueCallback: any;
+
+  constructor() {
+    super({
+      uuid: 'ec0e',
+      properties: ['read', 'write', 'notify'],
+      value: null
+    });
+    this._value = new ArrayBuffer(0);
+    this._updateValueCallback = null;
+  }
+
+  onReadRequest(offset, callback) {
+    console.log('EchoCharacteristic - onReadRequest: value = ' + this._value.toString('hex'));
+
+    callback(Characteristic.RESULT_SUCCESS, this._value);
+  }
+
+  onWriteRequest(data, offset, withoutResponse, callback) {
+    this._value = data;
+
+    console.log('EchoCharacteristic - onWriteRequest: value = ' + this._value.toString('hex'));
+
+    if (this._updateValueCallback) {
+      console.log('EchoCharacteristic - onWriteRequest: notifying');
+
+      this._updateValueCallback(this._value);
+    }
+
+    callback(Characteristic.RESULT_SUCCESS);
+  }
+
+  onSubscribe(maxValueSize, updateValueCallback) {
+    console.log('EchoCharacteristic - onSubscribe');
+
+    this._updateValueCallback = updateValueCallback;
+  }
+
+  onUnsubscribefunction() {
+    console.log('EchoCharacteristic - onUnsubscribe');
+
+    this._updateValueCallback = null;
+  }
+}

--- a/examples/echo-typescript/main.ts
+++ b/examples/echo-typescript/main.ts
@@ -1,0 +1,30 @@
+import * as Bleno from '../..';
+import { PrimaryService } from '../..';
+import { EchoCharacteristic } from './characteristic';
+
+console.log('bleno - echo with TypeScript');
+
+
+Bleno.on('stateChange', function(state) {
+  console.log('on -> stateChange: ' + state);
+
+  if (state === 'poweredOn') {
+    Bleno.startAdvertising('echo', ['ec00']);
+  } else {
+    Bleno.stopAdvertising();
+  }
+});
+
+let characteristic = new EchoCharacteristic();
+Bleno.on('advertisingStart', function(error) {
+  console.log('on -> advertisingStart: ' + (error ? 'error ' + error : 'success'));
+
+  if (!error) {
+    Bleno.setServices([
+      new PrimaryService({
+        uuid: 'ec00',
+        characteristics: [ characteristic ]
+      })
+    ]);
+  }
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,11 @@ export as namespace bleno;
 
 declare namespace bleno {
   class Characteristic {
-      uuid: any;
-      properties: any;
-      secure: any;
-      value: any;
-      descriptors: any;
+      public uuid: any;
+      public properties: any;
+      public secure: any;
+      public value: any;
+      public descriptors: any;
 
       constructor(options: any);
       onIndicate(): void;
@@ -25,16 +25,16 @@ declare namespace bleno {
   }
 
   class Descriptor {
-      uuid: any;
-      value: any;
+      public uuid: any;
+      public value: any;
 
       constructor(options: any);
       toString(): any;
   }
 
   class PrimaryService {
-      uuid: any;
-      characeteristics: any;
+      public uuid: any;
+      public characteristics: any;
 
       constructor(options: any);
       toString(): any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,57 @@
+export = bleno;
+export as namespace bleno;
+
+declare namespace bleno {
+  class Characteristic {
+      uuid: any;
+      properties: any;
+      secure: any;
+      value: any;
+      descriptors: any;
+
+      constructor(options: any);
+      onIndicate(): void;
+      onNotify(): void;
+      onReadRequest(offset: any, callback: any): void;
+      onSubscribe(maxValueSize: any, updateValueCallback: any): void;
+      onUnsubscribe(): void;
+      onWriteRequest(data: any, offset: any, withoutResponse: any, callback: any): void;
+      toString(): any;
+      static RESULT_ATTR_NOT_LONG: number;
+      static RESULT_INVALID_ATTRIBUTE_LENGTH: number;
+      static RESULT_INVALID_OFFSET: number;
+      static RESULT_SUCCESS: number;
+      static RESULT_UNLIKELY_ERROR: number;
+  }
+
+  class Descriptor {
+      uuid: any;
+      value: any;
+
+      constructor(options: any);
+      toString(): any;
+  }
+
+  class PrimaryService {
+      uuid: any;
+      characeteristics: any;
+
+      constructor(options: any);
+      toString(): any;
+  }
+
+  let platform: any;
+  let state: any;
+  let address: any;
+  let rssi: number;
+  let mtu: number;
+
+  function on(event: string, callback: any): any;
+  function startAdvertising(name: string, serviceUuids: any[], callback?: any): any;
+  function startAdvertisingIBeacon(uuid: string, major: number, minor: number, measuredPower: number, callback?: any): any;
+  function startAdvertisingWithEIRData(advertisementData: any, scanData?: any, callback?: any): any;
+  function stopAdvertising(callback?: any);
+  function setServices(services: any, callback?: any): any;
+  function disconnect(): any;
+  function updateRssi(callback?: any): any;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.1",
   "description": "A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals",
   "main": "index.js",
+  "types": "index.d.ts",
   "engines": {
     "node": ">=0.8"
   },
@@ -33,9 +34,11 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "jshint": "~2.3.0",
-    "should": "~2.0.2",
     "mocha": "~1.14.0",
-    "node-blink1": "~0.2.2"
+    "node-blink1": "~0.2.2",
+    "should": "~2.0.2",
+    "ts-node": "^2.0.0",
+    "typescript": "^2.1.5"
   },
   "dependencies": {
     "debug": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   ],
   "scripts": {
     "pretest": "jshint *.js lib/. test/. examples/.",
-    "test": "mocha -R spec test/*.js"
+    "test": "mocha -R spec test/*.js",
+    "typescript": "node_modules/.bin/ts-node examples/echo-typescript/main.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding TypeScript definition of Bleno together with the echo example adapted for TypeScript as POC.

On my code I can now do:

```
import { PrimaryService } from "bleno";
import * as Bleno from "bleno";
```

And get proper code completion with types