### PR TITLE
Add setDeviceName() and setMaxMtu() methods (Linux Only)

### DIFF
--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -194,6 +194,10 @@ Bleno.prototype.onAdvertisingStop = function() {
   this.emit('advertisingStop');
 };
 
+Bleno.prototype.setMaxMtu = function(mtu) {
+  return this._bindings.setMaxMtu(mtu);
+};
+
 Bleno.prototype.setDeviceName = function(name) {
   return this._bindings.setDeviceName(name);
 };

--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -194,6 +194,10 @@ Bleno.prototype.onAdvertisingStop = function() {
   this.emit('advertisingStop');
 };
 
+Bleno.prototype.setDeviceName = function(name) {
+  return this._bindings.setDeviceName(name);
+};
+
 Bleno.prototype.setServices = function(services, callback) {
   if (callback) {
     this.once('servicesSet', callback);

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -49,6 +49,11 @@ BlenoBindings.prototype.stopAdvertising = function() {
   this._gap.stopAdvertising();
 };
 
+
+BlenoBindings.prototype.setDeviceName = function(mtu) {
+  this._gatt.setDeviceName(mtu);
+};
+
 BlenoBindings.prototype.setServices = function(services) {
   this._gatt.setServices(services);
 

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -9,6 +9,11 @@ var Hci = require('./hci');
 var Gap = require('./gap');
 var Gatt = require('./gatt');
 
+var MaxMtus = {
+  '2' : 23, // Intel Corporation
+  '93': 23 // Realtek Semiconductor Corporation
+};
+
 var BlenoBindings = function() {
   this._state = null;
 
@@ -49,6 +54,9 @@ BlenoBindings.prototype.stopAdvertising = function() {
   this._gap.stopAdvertising();
 };
 
+BlenoBindings.prototype.setMaxMtu = function(mtu) {
+  this._gatt.setMaxMtu(mtu);
+};
 
 BlenoBindings.prototype.setDeviceName = function(mtu) {
   this._gatt.setDeviceName(mtu);
@@ -126,12 +134,9 @@ BlenoBindings.prototype.onAddressChange = function(address) {
 };
 
 BlenoBindings.prototype.onReadLocalVersion = function(hciVer, hciRev, lmpVer, manufacturer, lmpSubVer) {
-  if (manufacturer === 2) {
-    // Intel Corporation
-    this._gatt.maxMtu = 23;
-  } else if (manufacturer === 93) {
-    // Realtek Semiconductor Corporation
-    this._gatt.maxMtu = 23;
+  var manuMaxMtu = MaxMtus[manufacturer.toString()];
+  if (manuMaxMtu) {
+    this.setMaxMtu(manuMaxMtu);
   }
 };
 

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -64,8 +64,8 @@ var ATT_ECODE_INSUFF_RESOURCES      = 0x11;
 var ATT_CID = 0x0004;
 
 var Gatt = function() {
-  this.maxMtu = 256;
   this._mtu = 23;
+  this._maxMtu = process.env.BLENO_MAX_MTU || 256;
   this._preparedWriteRequest = null;
   this._deviceName = process.env.BLENO_DEVICE_NAME || os.hostname();
 
@@ -76,6 +76,10 @@ var Gatt = function() {
 };
 
 util.inherits(Gatt, events.EventEmitter);
+
+Gatt.prototype.setMaxMtu = function(mtu) {
+  this._maxMtu = mtu;
+};
 
 Gatt.prototype.setDeviceName = function(name) {
   this._deviceName = name;
@@ -380,13 +384,14 @@ Gatt.prototype.handleMtuRequest = function(request) {
 
   if (mtu < 23) {
     mtu = 23;
-  } else if (mtu > this.maxMtu) {
-    mtu = this.maxMtu;
+  } else if (mtu > this._maxMtu) {
+    mtu = this._maxMtu;
   }
 
-  this._mtu = mtu;
-
-  this.emit('mtuChange', this._mtu);
+  if (this._mtu !== mtu) {
+    this._mtu = mtu;
+    this.emit('mtuChange', this._mtu);
+  }
 
   var response = new Buffer(3);
 

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -67,6 +67,7 @@ var Gatt = function() {
   this.maxMtu = 256;
   this._mtu = 23;
   this._preparedWriteRequest = null;
+  this._deviceName = process.env.BLENO_DEVICE_NAME || os.hostname();
 
   this.setServices([]);
 
@@ -76,8 +77,12 @@ var Gatt = function() {
 
 util.inherits(Gatt, events.EventEmitter);
 
+Gatt.prototype.setDeviceName = function(name) {
+  this._deviceName = name;
+};
+
 Gatt.prototype.setServices = function(services) {
-  var deviceName = process.env.BLENO_DEVICE_NAME || os.hostname();
+  var deviceName = this._deviceName;
 
   // base services and characteristics
   var allServices = [

--- a/lib/mac/bindings.js
+++ b/lib/mac/bindings.js
@@ -157,6 +157,10 @@ blenoBindings.on('kCBMsgId17', function(args) {
   this.emit('advertisingStop');
 });
 
+blenoBindings.setDeviceName = function (name) {
+  console.warn('bleno does not support setDeviceName() on macOS/OSX');
+};
+
 blenoBindings.setServices = function(services) {
   this.sendCBMsg(12, null); // remove all services
 

--- a/lib/mac/bindings.js
+++ b/lib/mac/bindings.js
@@ -157,6 +157,10 @@ blenoBindings.on('kCBMsgId17', function(args) {
   this.emit('advertisingStop');
 });
 
+blenoBindings.setMaxMtu = function(mtu) {
+  console.warn('bleno does not support setMaxMtu() on macOS/OSX');
+};
+
 blenoBindings.setDeviceName = function (name) {
   console.warn('bleno does not support setDeviceName() on macOS/OSX');
 };


### PR DESCRIPTION
Think it's very useful to be able to set the device name and maxMtu sizes at runtime, especially the mtu size.

Had an issue with Atheros adapter not working with maxMtu > 23, having a runtime option allows for easy testing/debugging with different values. Supports both the runtime method and a new BLENO_MAX_MTU env var.

