### PR TITLE
Fragmentation and flow control support for HCI/ACL packets

### DIFF
--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -86,7 +86,7 @@ Bleno.prototype.onMtuChange = function(mtu) {
 };
 
 Bleno.prototype.onDisconnect = function(clientAddress) {
-  debug('disconnect' + clientAddress);
+  debug('disconnect ' + clientAddress);
   this.emit('disconnect', clientAddress);
 };
 

--- a/lib/hci-socket/acl-stream.js
+++ b/lib/hci-socket/acl-stream.js
@@ -18,7 +18,7 @@ util.inherits(AclStream, events.EventEmitter);
 
 
 AclStream.prototype.write = function(cid, data) {
-  this._hci.writeAclDataPkt(this._handle, cid, data);
+  this._hci.queueAclDataPkt(this._handle, cid, data);
 };
 
 AclStream.prototype.push = function(cid, data) {

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -121,13 +121,6 @@ BlenoBindings.prototype.onAddressChange = function(address) {
 };
 
 BlenoBindings.prototype.onReadLocalVersion = function(hciVer, hciRev, lmpVer, manufacturer, lmpSubVer) {
-  if (manufacturer === 2) {
-    // Intel Corporation
-    this._gatt.maxMtu = 23;
-  } else if (manufacturer === 93) {
-    // Realtek Semiconductor Corporation
-    this._gatt.maxMtu = 23;
-  }
 };
 
 BlenoBindings.prototype.onAdvertisingStart = function(error) {

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -33,6 +33,7 @@ var OCF_WRITE_LE_HOST_SUPPORTED = 0x006d;
 
 var OGF_INFO_PARAM = 0x04;
 var OCF_READ_LOCAL_VERSION = 0x0001;
+var OCF_READ_BUFFER_SIZE = 0x0005;
 var OCF_READ_BD_ADDR = 0x0009;
 
 var OGF_STATUS_PARAM = 0x05;
@@ -40,6 +41,7 @@ var OCF_READ_RSSI = 0x0005;
 
 var OGF_LE_CTL = 0x08;
 var OCF_LE_SET_EVENT_MASK = 0x0001;
+var OCF_LE_READ_BUFFER_SIZE = 0x0002;
 var OCF_LE_SET_ADVERTISING_PARAMETERS = 0x0006;
 var OCF_LE_SET_ADVERTISING_DATA = 0x0008;
 var OCF_LE_SET_SCAN_RESPONSE_DATA = 0x0009;
@@ -54,11 +56,13 @@ var READ_LE_HOST_SUPPORTED_CMD = OCF_READ_LE_HOST_SUPPORTED | OGF_HOST_CTL << 10
 var WRITE_LE_HOST_SUPPORTED_CMD = OCF_WRITE_LE_HOST_SUPPORTED | OGF_HOST_CTL << 10;
 
 var READ_LOCAL_VERSION_CMD = OCF_READ_LOCAL_VERSION | (OGF_INFO_PARAM << 10);
+var READ_BUFFER_SIZE_CMD = OCF_READ_BUFFER_SIZE | (OGF_INFO_PARAM << 10);
 var READ_BD_ADDR_CMD = OCF_READ_BD_ADDR | (OGF_INFO_PARAM << 10);
 
 var READ_RSSI_CMD = OCF_READ_RSSI | OGF_STATUS_PARAM << 10;
 
 var LE_SET_EVENT_MASK_CMD = OCF_LE_SET_EVENT_MASK | OGF_LE_CTL << 10;
+var LE_READ_BUFFER_SIZE_CMD = OCF_LE_READ_BUFFER_SIZE | OGF_LE_CTL << 10;
 var LE_SET_ADVERTISING_PARAMETERS_CMD = OCF_LE_SET_ADVERTISING_PARAMETERS | OGF_LE_CTL << 10;
 var LE_SET_ADVERTISING_DATA_CMD = OCF_LE_SET_ADVERTISING_DATA | OGF_LE_CTL << 10;
 var LE_SET_SCAN_RESPONSE_DATA_CMD = OCF_LE_SET_SCAN_RESPONSE_DATA | OGF_LE_CTL << 10;
@@ -74,6 +78,9 @@ var Hci = function() {
   this._isDevUp = null;
   this._state = null;
   this._deviceId = null;
+  // le-u min payload size + l2cap header size
+  // see Bluetooth spec 4.2 [Vol 3, Part A, Chapter 4]
+  this._acl_mtu = 23 + 4;
 
   this._handleBuffers = {};
 
@@ -111,12 +118,7 @@ Hci.prototype.pollIsDevUp = function() {
   if (this._isDevUp !== isDevUp) {
     if (isDevUp) {
       this.setSocketFilter();
-      this.setEventMask();
-      this.setLeEventMask();
-      this.readLocalVersion();
-      this.writeLeHostSupported();
-      this.readLeHostSupported();
-      this.readBdAddr();
+      this.initDev();
     } else {
       this.emit('stateChange', 'poweredOff');
     }
@@ -126,6 +128,16 @@ Hci.prototype.pollIsDevUp = function() {
 
   setTimeout(this.pollIsDevUp.bind(this), 1000);
 };
+
+Hci.prototype.initDev = function() {
+  this.setEventMask();
+  this.setLeEventMask();
+  this.readLocalVersion();
+  this.writeLeHostSupported();
+  this.readLeHostSupported();
+  this.readBdAddr();
+  this.leReadBufferSize();
+}
 
 Hci.prototype.setSocketFilter = function() {
   var filter = new Buffer(14);
@@ -371,20 +383,60 @@ Hci.prototype.readRssi = function(handle) {
   this._socket.write(cmd);
 };
 
-Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
-  var pkt = new Buffer(9 + data.length);
+Hci.prototype.leReadBufferSize = function() {
+  var cmd = new Buffer(4);
 
   // header
-  pkt.writeUInt8(HCI_ACLDATA_PKT, 0);
-  pkt.writeUInt16LE(handle | ACL_START_NO_FLUSH << 12, 1);
-  pkt.writeUInt16LE(data.length + 4, 3); // data length 1
-  pkt.writeUInt16LE(data.length, 5); // data length 2
-  pkt.writeUInt16LE(cid, 7);
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_READ_BUFFER_SIZE_CMD, 1);
 
-  data.copy(pkt, 9);
+  // length
+  cmd.writeUInt8(0x0, 3);
 
-  debug('write acl data pkt - writing: ' + pkt.toString('hex'));
-  this._socket.write(pkt);
+  debug('le read buffer size - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.readBufferSize = function() {
+  var cmd = new Buffer(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(READ_BUFFER_SIZE_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x0, 3);
+
+  debug('read buffer size - writing: ' + cmd.toString('hex'));
+  this._socket.write(cmd);
+};
+
+Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
+  var hf = handle | ACL_START_NO_FLUSH << 12;
+  // l2cap pdu may be fragmented on hci level
+  var l2capPdu = new Buffer(4 + data.length);
+  l2capPdu.writeUInt16LE(data.length, 0);
+  l2capPdu.writeUInt16LE(cid, 2);
+  data.copy(l2capPdu, 4);
+  var fragId = 0;
+
+  while (l2capPdu.length) {
+    var frag = l2capPdu.slice(0, this._acl_mtu);
+    l2capPdu = l2capPdu.slice(frag.length);
+    var pkt = new Buffer(5 + frag.length);
+
+    // hci header
+    pkt.writeUInt8(HCI_ACLDATA_PKT, 0);
+    pkt.writeUInt16LE(hf, 1);
+    hf |= ACL_CONT << 12;
+    pkt.writeUInt16LE(frag.length, 3); // hci pdu length
+
+    frag.copy(pkt, 5);
+
+    debug('write acl data pkt frag ' + fragId + ' - writing: ' + pkt.toString('hex'));
+    this._socket.write(pkt);
+    fragId++;
+  }
 };
 
 Hci.prototype.onSocketData = function(data) {
@@ -494,12 +546,7 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
   var handle;
 
   if (cmd === RESET_CMD) {
-    this.setEventMask();
-    this.setLeEventMask();
-    this.readLocalVersion();
-    this.writeLeHostSupported();
-    this.readLeHostSupported();
-    this.readBdAddr();
+    this.initDev();
   } else if (cmd === READ_LE_HOST_SUPPORTED_CMD) {
     if (status === 0) {
       var le = result.readUInt8(0);
@@ -553,8 +600,35 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
 
     debug('\t\t\thandle = ' + handle);
     this.emit('leLtkNegReply', handle);
+  } else if (cmd === LE_READ_BUFFER_SIZE_CMD) {
+    if (!status) {
+      this.processLeReadBufferSize(result);
+    }
+  } else if (cmd === READ_BUFFER_SIZE_CMD) {
+    if (!status) {
+      var acl_mtu = result.readUInt16LE(0);
+      // sanity
+      if (acl_mtu) {
+	debug('br/edr acl_mtu = ' + acl_mtu);
+	this._acl_mtu = acl_mtu;
+      }
+    }
   }
 };
+
+Hci.prototype.processLeReadBufferSize = function(result) {
+  var acl_mtu = result.readUInt16LE(0);
+  var acl_queue = result.readUInt8(2);
+  if (!acl_mtu) {
+    // as per Bluetooth specs
+    debug('falling back to br/edr buffer size');
+    this.readBufferSize();
+  } else {
+    debug('le acl_mtu = ' + acl_mtu);
+    debug('le acl_queue = ' + acl_queue);
+    this._acl_mtu = acl_mtu;
+  }
+}
 
 Hci.prototype.processLeMetaEvent = function(eventType, status, data) {
   if (eventType === EVT_LE_CONN_COMPLETE) {

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -17,6 +17,7 @@ var EVT_DISCONN_COMPLETE = 0x05;
 var EVT_ENCRYPT_CHANGE = 0x08;
 var EVT_CMD_COMPLETE = 0x0e;
 var EVT_CMD_STATUS = 0x0f;
+var EVT_NUMBER_OF_COMPLETED_PACKETS = 0x13;
 var EVT_LE_META_EVENT = 0x3e;
 
 var EVT_LE_CONN_COMPLETE = 0x01;
@@ -80,9 +81,10 @@ var Hci = function() {
   this._deviceId = null;
   // le-u min payload size + l2cap header size
   // see Bluetooth spec 4.2 [Vol 3, Part A, Chapter 4]
-  this._acl_mtu = 23 + 4;
+  this._aclMtu = 23 + 4;
+  this._aclMaxInProgress = 1;
 
-  this._handleBuffers = {};
+  this.resetBuffers();
 
   this.on('stateChange', this.onStateChange.bind(this));
 };
@@ -112,6 +114,12 @@ Hci.prototype.init = function() {
   }
 };
 
+Hci.prototype.resetBuffers = function() {
+  this._handleAclsInProgress = {};
+  this._handleBuffers = {};
+  this._aclOutQueue = [];
+}
+
 Hci.prototype.pollIsDevUp = function() {
   var isDevUp = this._socket.isDevUp();
 
@@ -130,6 +138,7 @@ Hci.prototype.pollIsDevUp = function() {
 };
 
 Hci.prototype.initDev = function() {
+  this.resetBuffers();
   this.setEventMask();
   this.setLeEventMask();
   this.readLocalVersion();
@@ -142,7 +151,7 @@ Hci.prototype.initDev = function() {
 Hci.prototype.setSocketFilter = function() {
   var filter = new Buffer(14);
   var typeMask = (1 << HCI_EVENT_PKT)| (1 << HCI_ACLDATA_PKT);
-  var eventMask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) | (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS);
+  var eventMask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) | (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS) | ( 1 << EVT_NUMBER_OF_COMPLETED_PACKETS);
   var eventMask2 = (1 << (EVT_LE_META_EVENT - 32));
   var opcode = 0;
 
@@ -411,7 +420,7 @@ Hci.prototype.readBufferSize = function() {
   this._socket.write(cmd);
 };
 
-Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
+Hci.prototype.queueAclDataPkt = function(handle, cid, data) {
   var hf = handle | ACL_START_NO_FLUSH << 12;
   // l2cap pdu may be fragmented on hci level
   var l2capPdu = new Buffer(4 + data.length);
@@ -421,7 +430,7 @@ Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
   var fragId = 0;
 
   while (l2capPdu.length) {
-    var frag = l2capPdu.slice(0, this._acl_mtu);
+    var frag = l2capPdu.slice(0, this._aclMtu);
     l2capPdu = l2capPdu.slice(frag.length);
     var pkt = new Buffer(5 + frag.length);
 
@@ -432,12 +441,40 @@ Hci.prototype.writeAclDataPkt = function(handle, cid, data) {
     pkt.writeUInt16LE(frag.length, 3); // hci pdu length
 
     frag.copy(pkt, 5);
-
-    debug('write acl data pkt frag ' + fragId + ' - writing: ' + pkt.toString('hex'));
-    this._socket.write(pkt);
-    fragId++;
+    
+    this._aclOutQueue.push({
+      handle: handle,
+      pkt: pkt,
+      fragId: fragId++
+    });
   }
+  
+  this.pushAclOutQueue();
 };
+
+Hci.prototype.pushAclOutQueue = function() {
+  var inProgress = 0;
+  for (var handle in this._handleAclsInProgress) {
+    inProgress += this._handleAclsInProgress[handle];
+  }
+  while (inProgress < this._aclMaxInProgress && this._aclOutQueue.length) {
+    inProgress++;
+    this.writeOneAclDataPkt();
+  }
+  
+  if (inProgress >= this._aclMaxInProgress && this._aclOutQueue.length) {
+    debug("acl out queue congested");
+    debug("\tin progress = " + inProgress);
+    debug("\twaiting = " + this._aclOutQueue.length);
+  }
+}
+
+Hci.prototype.writeOneAclDataPkt = function() {
+  var pkt = this._aclOutQueue.shift();
+  this._handleAclsInProgress[pkt.handle]++;
+  debug('write acl data pkt frag ' + pkt.fragId + ' handle ' + pkt.handle + ' - writing: ' + pkt.pkt.toString('hex'));
+  this._socket.write(pkt.pkt);
+}
 
 Hci.prototype.onSocketData = function(data) {
   debug('onSocketData: ' + data.toString('hex'));
@@ -459,6 +496,27 @@ Hci.prototype.onSocketData = function(data) {
       debug('\t\thandle = ' + handle);
       debug('\t\treason = ' + reason);
 
+      /* As per Bluetooth Core specs:
+      When the Host receives a Disconnection Complete, Disconnection Physical
+      Link Complete or Disconnection Logical Link Complete event, the Host shall
+      assume that all unacknowledged HCI Data Packets that have been sent to the
+      Controller for the returned Handle have been flushed, and that the
+      corresponding data buffers have been freed. */
+      delete this._handleAclsInProgress[handle];
+      var aclOutQueue = [];
+      var discarded = 0;
+      for (var i in this._aclOutQueue) {
+        if (this._aclOutQueue[i].handle != handle) {
+          aclOutQueue.push(this._aclOutQueue[i]);
+        } else {
+          discarded++;
+        }
+      }
+      if (discarded) {
+        debug('\t\tacls discarded = ' + discarded);
+      }
+      this._aclOutQueue = aclOutQueue;
+      this.pushAclOutQueue();
       this.emit('disconnComplete', handle, reason);
     } else if (subEventType === EVT_ENCRYPT_CHANGE) {
       handle =  data.readUInt16LE(4);
@@ -469,10 +527,12 @@ Hci.prototype.onSocketData = function(data) {
 
       this.emit('encryptChange', handle, encrypt);
     } else if (subEventType === EVT_CMD_COMPLETE) {
+      var ncmd = data.readUInt8(3);
       var cmd = data.readUInt16LE(4);
       var status = data.readUInt8(6);
       var result = data.slice(7);
 
+      debug('\t\tncmd = ' + ncmd);
       debug('\t\tcmd = ' + cmd);
       debug('\t\tstatus = ' + status);
       debug('\t\tresult = ' + result.toString('hex'));
@@ -488,6 +548,26 @@ Hci.prototype.onSocketData = function(data) {
       debug('\t\tLE meta event data = ' + leMetaEventData.toString('hex'));
 
       this.processLeMetaEvent(leMetaEventType, leMetaEventStatus, leMetaEventData);
+    } else if (subEventType === EVT_NUMBER_OF_COMPLETED_PACKETS) {
+      var handles = data.readUInt8(3);
+      for (var i = 0; i < handles; i++) {
+        var handle = data.readUInt16LE(4 + i * 4);
+        var pkts = data.readUInt16LE(6 + i * 4);
+        debug("\thandle = " + handle);
+        debug("\t\tcompleted = " + pkts);
+        if (this._handleAclsInProgress[handle] === undefined) {
+          debug("\t\talready closed");
+          continue;
+        }
+        if (pkts > this._handleAclsInProgress[handle]) {
+          // Linux kernel may send acl packets by itself, so be ready for underflow
+          this._handleAclsInProgress[handle] = 0;
+        } else {
+          this._handleAclsInProgress[handle] -= pkts;
+        }
+        debug("\t\tin progress = " + this._handleAclsInProgress[handle]);
+      }
+      this.pushAclOutQueue();
     }
   } else if (HCI_ACLDATA_PKT === eventType) {
     var flags = data.readUInt16LE(1) >> 12;
@@ -606,27 +686,31 @@ Hci.prototype.processCmdCompleteEvent = function(cmd, status, result) {
     }
   } else if (cmd === READ_BUFFER_SIZE_CMD) {
     if (!status) {
-      var acl_mtu = result.readUInt16LE(0);
+      var aclMtu = result.readUInt16LE(0);
+      var aclMaxInProgress = result.readUInt16LE(3);
       // sanity
-      if (acl_mtu) {
-	debug('br/edr acl_mtu = ' + acl_mtu);
-	this._acl_mtu = acl_mtu;
+      if (aclMtu && aclMaxInProgress) {
+	debug('br/edr acl mtu = ' + aclMtu);
+	debug('br/edr acl max pkts = ' + aclMaxInProgress);
+	this._aclMtu = aclMtu;
+	this._aclMaxInProgress = aclMaxInProgress;
       }
     }
   }
 };
 
 Hci.prototype.processLeReadBufferSize = function(result) {
-  var acl_mtu = result.readUInt16LE(0);
-  var acl_queue = result.readUInt8(2);
-  if (!acl_mtu) {
+  var aclMtu = result.readUInt16LE(0);
+  var aclMaxInProgress = result.readUInt8(2);
+  if (!aclMtu) {
     // as per Bluetooth specs
     debug('falling back to br/edr buffer size');
     this.readBufferSize();
   } else {
-    debug('le acl_mtu = ' + acl_mtu);
-    debug('le acl_queue = ' + acl_queue);
-    this._acl_mtu = acl_mtu;
+    debug('le acl mtu = ' + aclMtu);
+    debug('le acl max in progress = ' + aclMaxInProgress);
+    this._aclMtu = aclMtu;
+    this._aclMaxInProgress = aclMaxInProgress;
   }
 }
 
@@ -656,6 +740,8 @@ Hci.prototype.processLeConnComplete = function(status, data) {
   debug('\t\t\tlatency = ' + latency);
   debug('\t\t\tsupervision timeout = ' + supervisionTimeout);
   debug('\t\t\tmaster clock accuracy = ' + masterClockAccuracy);
+  
+  this._handleAclsInProgress[handle] = 0;
 
   this.emit('leConnComplete', status, handle, role, addressType, address, interval, latency, supervisionTimeout, masterClockAccuracy);
 };


### PR DESCRIPTION
Bleno implementation was missing the fact, that HCI/ACL MTU is different from ATT MTU and packets on HCI/ACL level should be fragmented independently of ATT MTU.
This correction makes MTU workarounds unnecessary.
Tested with the following USB connected BT chips:
- Intel 7260 (LE ACL MTU 27)
- Broadcom Corp. BCM20702A0 Bluetooth 4.0 (LE ACL MTU 27)
- Cambridge Silicon Radio CSR8510 A10 (BR/EDR ACL MTU 310)