### PR TITLE
Reinforce lint and fix undefined variables in gatt.js

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+    "undef": true,
+    "node": true
+}

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -586,6 +586,7 @@ Gatt.prototype.handleReadByGroupRequest = function(request) {
 
 Gatt.prototype.handleReadByTypeRequest = function(request) {
   var response = null;
+  var requestType = request[0];
 
   var startHandle = request.readUInt16LE(1);
   var endHandle = request.readUInt16LE(3);

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -798,7 +798,7 @@ Gatt.prototype.handleReadOrReadBlobRequest = function(request) {
 
     if (result === ATT_ECODE_SUCCESS && data && offset) {
       if (data.length < offset) {
-        errorCode = ATT_ECODE_INVALID_OFFSET;
+        result = ATT_ECODE_INVALID_OFFSET;
         data = null;
       } else {
         data = data.slice(offset);

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -399,6 +399,7 @@ Gatt.prototype.handleFindInfoRequest = function(request) {
 
   var infos = [];
   var uuid = null;
+  var i;
 
   for (i = startHandle; i <= endHandle; i++) {
     var handle = this._handles[i];
@@ -720,6 +721,7 @@ Gatt.prototype.handleReadOrReadBlobRequest = function(request) {
   var offset = (requestType === ATT_OP_READ_BLOB_REQ) ? request.readUInt16LE(3) : 0;
 
   var handle = this._handles[valueHandle];
+  var i;
 
   if (handle) {
     var result = null;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "jshint": "~2.3.0",
+    "jshint": "~2.9.4",
     "should": "~2.0.2",
     "mocha": "~1.14.0",
     "node-blink1": "~0.2.2"

--- a/test/test-characteristic.js
+++ b/test/test-characteristic.js
@@ -1,3 +1,5 @@
+/* jshint mocha: true */
+
 var should = require('should');
 
 var Characteristic = require('../lib/characteristic');

--- a/test/test-descriptor.js
+++ b/test/test-descriptor.js
@@ -1,3 +1,5 @@
+/* jshint mocha: true */
+
 var should = require('should');
 
 var Descriptor = require('../lib/descriptor');

--- a/test/test-primary-service.js
+++ b/test/test-primary-service.js
@@ -1,3 +1,5 @@
+/* jshint mocha: true */
+
 var should = require('should');
 
 var PrimaryService = require('../lib/primary-service');


### PR DESCRIPTION
The pull requests fixes #273 and includes the following changes:

- Reinforce lint by checking for undefined variables using jshint (1944aac)
- Update jshint to 2.9.4 to be able to use the mocha option (6bce8a7)
- Declaration of variables that would otherwise leak in the global scope or make node crash in strict mode (ed50dea)
- Two fixes when undeclared variables are used. This would have unmistakenly led to bugs, whether strict mode is enabled or not (3113dd1, 0b31bc8)

I am looking forward to a review ;). Hope it helps.