### PR TITLE
Don't initialize bindings until first state change listener added

### DIFF
--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -23,6 +23,7 @@ if (platform === 'darwin') {
 }
 
 function Bleno() {
+  this.initialized = false;
   this.platform = 'unknown';
   this.state = 'unknown';
   this.address = 'unknown';
@@ -43,7 +44,13 @@ function Bleno() {
 
   this._bindings.on('rssiUpdate', this.onRssiUpdate.bind(this));
 
-  this._bindings.init();
+  this.on('newListener', function(event) {
+    if (event === 'stateChange' && !this.initialized) {
+      this._bindings.init();
+
+      this.initialized = true;
+    }
+  }.bind(this));
 }
 
 util.inherits(Bleno, events.EventEmitter);


### PR DESCRIPTION
Helps avoid conditions like https://github.com/sandeepmistry/bleno/issues/286.

Could also be ported to noble ...

@jacobrosenthal thoughts?