### PR TITLE
Add L2CAP LE Credit Based Connection Support

### DIFF
--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -13,11 +13,13 @@ var Descriptor = require('./descriptor');
 var bindings = null;
 
 var platform = os.platform();
+var isHCIbased = false;
 
 if (platform === 'darwin') {
   bindings = require('./mac/bindings');
 } else if (platform === 'linux' || platform === 'freebsd' || platform === 'win32' || platform === 'android') {
   bindings = require('./hci-socket/bindings');
+  isHCIbased = true;
 } else {
   throw new Error('Unsupported platform');
 }
@@ -43,6 +45,8 @@ function Bleno() {
   this._bindings.on('disconnect', this.onDisconnect.bind(this));
 
   this._bindings.on('rssiUpdate', this.onRssiUpdate.bind(this));
+
+  this._bindings.on('l2cap-newStream', this.onL2CAPNewStream.bind(this));
 
   this.on('newListener', function(event) {
     if (event === 'stateChange' && !this.initialized) {
@@ -236,5 +240,29 @@ Bleno.prototype.updateRssi = function(callback) {
 Bleno.prototype.onRssiUpdate = function(rssi) {
   this.emit('rssiUpdate', rssi);
 };
+
+Bleno.prototype.publishL2CAPChannel = function(psm, callback) {
+  if (isHCIbased === false) {
+    debug('Not Supported');
+    if (callback) {
+      callback(false, 'Not Supported');
+    }
+    return;
+  }
+
+  if (!process.env.HCI_CHANNEL_USER) {
+    debug('L2CAP Channel requires HCI_CHANNEL_USER');
+    if (callback) {
+      callback(false, 'L2CAP Channel requires HCI_CHANNEL_USER');
+    }
+    return;
+  }
+
+  this._bindings.publishL2CAPChannel(psm, callback);
+};
+
+Bleno.prototype.onL2CAPNewStream = function(stream) {
+  this.emit('l2cap-newStream', stream);
+}
 
 module.exports = Bleno;

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -8,6 +8,7 @@ var AclStream = require('./acl-stream');
 var Hci = require('./hci');
 var Gap = require('./gap');
 var Gatt = require('./gatt');
+var L2cap = require('./l2cap');
 
 var BlenoBindings = function() {
   this._state = null;
@@ -17,6 +18,7 @@ var BlenoBindings = function() {
   this._hci = new Hci();
   this._gap = new Gap(this._hci);
   this._gatt = new Gatt(this._hci);
+  this._l2cap = new L2cap(this._hci);
 
   this._address = null;
   this._handle = null;
@@ -69,6 +71,16 @@ BlenoBindings.prototype.updateRssi = function() {
   }
 };
 
+BlenoBindings.prototype.publishL2CAPChannel = function(psm, callback) {
+  if (this._l2cap) {
+    this._l2cap.publishL2CAPChannel(psm, callback);
+  } else {
+    if (callback) {
+      callback(false, 'unexpected state');
+    }
+  }
+};
+
 BlenoBindings.prototype.init = function() {
   this.onSigIntBinded = this.onSigInt.bind(this);
 
@@ -91,6 +103,8 @@ BlenoBindings.prototype.init = function() {
   this._hci.on('encryptChange', this.onEncryptChange.bind(this));
   this._hci.on('leLtkNegReply', this.onLeLtkNegReply.bind(this));
   this._hci.on('aclDataPkt', this.onAclDataPkt.bind(this));
+
+  this._l2cap.on('newStream', this.onL2CAPNewStream.bind(this));
 
   this.emit('platform', os.platform());
 
@@ -141,6 +155,7 @@ BlenoBindings.prototype.onLeConnComplete = function(status, handle, role, addres
   this._handle = handle;
   this._aclStream = new AclStream(this._hci, handle, this._hci.addressType, this._hci.address, addressType, address);
   this._gatt.setAclStream(this._aclStream);
+  this._l2cap.setAclStream(this._aclStream);
 
   this.emit('accept', address);
 };
@@ -193,6 +208,10 @@ BlenoBindings.prototype.onAclDataPkt = function(handle, cid, data) {
   if (this._handle === handle && this._aclStream) {
     this._aclStream.push(cid, data);
   }
+};
+
+BlenoBindings.prototype.onL2CAPNewStream = function(stream) {
+  this.emit('l2cap-newStream', stream);
 };
 
 BlenoBindings.prototype.onSigInt = function() {

--- a/lib/hci-socket/l2cap-stream.js
+++ b/lib/hci-socket/l2cap-stream.js
@@ -1,0 +1,91 @@
+var debug = require('debug')('l2cap-stream');
+
+var events = require('events');
+var util = require('util');
+
+var L2CAPStream = function(l2cap, psm, channel, mtu, mps, credits) {
+  this.psm = psm;
+
+  this._isValid = true;
+  this._l2cap = l2cap;
+  this._channel = channel;
+  this._mtu = mtu;
+  this._mps = mps;
+  this._credits = credits;
+
+  this._expectedLength = 0;
+  this._pendingBuffer = null;
+};
+
+util.inherits(L2CAPStream, events.EventEmitter);
+
+
+L2CAPStream.prototype.write = function(data) {
+  if (!this._isValid) {
+    throw 'Invalid L2CAP Stream';
+    return;
+  }
+
+  if (!data) {
+    return;
+  }
+
+  if ((data.length + 2) <= this._mps) {
+    var lengthBuf = new Buffer(2);
+    lengthBuf.writeUInt16LE(data.length);
+    var dataBuf = Buffer.concat([
+      lengthBuf,
+      data
+    ]);
+
+    this._l2cap.writeChannelData(this._channel, dataBuf);
+  } else {
+    var buf = data;
+    var lengthBuf = new Buffer(2);
+
+    while(buf.length) {
+      var frag = buf.slice(0, (this._mps - 2));
+      buf = buf.slice(frag.length);
+      lengthBuf.writeUInt16LE(frag.length);
+      var dataBuf = Buffer.concat([
+        lengthBuf,
+        frag
+      ]);
+
+      this._l2cap.writeChannelData(this._channel, dataBuf);
+    }
+  }
+};
+
+L2CAPStream.prototype.push = function(data) {
+  if (data) {
+    if (this._pendingBuffer === null) {
+      var length = data.readUInt16LE(0);
+      if (length === (data.length - 2)) {
+        this.emit('data', data.slice(2));
+      } else {
+        this._expectedLength = length;
+        this._pendingBuffer = data.slice(2);
+      }
+    } else {
+      this._pendingBuffer = Buffer.concat([
+        this._pendingBuffer,
+        data
+      ]);
+      if (this._pendingBuffer.length === this._expectedLength) {
+        this.emit('data', this._pendingBuffer);
+        this._pendingBuffer = null;
+        this._expectedLength = 0;
+      }
+    }
+  } else {
+    this.emit('end');
+  }
+};
+
+L2CAPStream.prototype.invalidate = function() {
+  this._isValid = false;
+  this.emit('invalidate');
+}
+
+module.exports = L2CAPStream;

--- a/lib/hci-socket/l2cap.js
+++ b/lib/hci-socket/l2cap.js
@@ -1,0 +1,284 @@
+var debug = require('debug')('l2cap');
+
+var events = require('events');
+var util = require('util');
+
+var L2CAPStream = require('./l2cap-stream');
+
+var LE_SIGNALING_CID = 0x0005;
+
+var L2CAP_COMMAND_REJECT = 0x01;
+var L2CAP_DISCONN_REQUEST = 0x06;
+var L2CAP_DISCONN_RESPONSE = 0x07;
+var L2CAP_CONN_PARAM_UPDATE_REQUEST = 0x12;
+var L2CAP_CONN_PARAM_UPDATE_RESPONSE = 0x13;
+var L2CAP_LE_CONN_REQUEST = 0x14;
+var L2CAP_LE_CONN_RESPONSE = 0x15;
+var L2CAP_LE_CREDITS = 0x16;
+
+// PSM
+var L2CAP_PSM_LE_DYN_START = 0x0080;
+var L2CAP_PSM_LE_DYN_END = 0x00FF;
+
+// Channel Identifier
+var L2CAP_CID_DYN_START = 0x0040;
+var L2CAP_CID_DYN_END = 0x007F;
+
+var L2cap = function() {
+  this._registeredPSMs = {};
+  this._activeStreams = {};
+
+  this.onAclStreamDataBinded = this.onAclStreamData.bind(this);
+  this.onAclStreamEndBinded = this.onAclStreamEnd.bind(this);
+};
+
+util.inherits(L2cap, events.EventEmitter);
+
+L2cap.prototype.publishL2CAPChannel = function(psm, callback) {
+  if (psm < L2CAP_PSM_LE_DYN_START || psm > L2CAP_PSM_LE_DYN_END) {
+    debug('invalid psm');
+    if (callback) {
+      callback(false, 'invalid psm');
+    }
+    return;
+  }
+
+  if (this._registeredPSMs[psm] !== undefined) {
+    debug('psm already registered');
+    if (callback) {
+      callback(false, 'psm already registered');
+    }
+    return;
+  }
+
+  this._registeredPSMs[psm] = true;
+  if (callback) {
+    callback(true);
+  }
+};
+
+L2cap.prototype.setAclStream = function(aclStream) {
+  this._aclStream = aclStream;
+
+  this._aclStream.on('data', this.onAclStreamDataBinded);
+  this._aclStream.on('end', this.onAclStreamEndBinded);
+};
+
+L2cap.prototype.onAclStreamData = function(cid, data) {
+  if (LE_SIGNALING_CID === cid) {
+    this.handleSignaling(data);
+    return;
+  }
+
+  if (cid >= L2CAP_CID_DYN_START && cid <= L2CAP_CID_DYN_END) {
+    var stream = this._activeStreams[cid];
+    if (stream) {
+      stream.push(data);
+    }
+  }
+};
+
+L2cap.prototype.onAclStreamEnd = function() {
+  this._aclStream.removeListener('data', this.onAclStreamDataBinded);
+  this._aclStream.removeListener('end', this.onAclStreamEndBinded);
+
+  Object.keys(this._activeStreams).forEach((key) => {
+    var stream = this._activeStreams[key];
+    stream.invalidate();
+  });
+
+  this._activeStreams = {};
+};
+
+L2cap.prototype.handleSignaling = function(data) {
+  var code = data.readUInt8(0);
+
+  if (L2CAP_COMMAND_REJECT === code) {
+    this.handleCommandRejection(data);
+  } else if (L2CAP_DISCONN_REQUEST === code) {
+    this.handleDisconnectRequest(data);
+  } else if (L2CAP_DISCONN_RESPONSE === code) {
+    this.handleDisconnectResponse(data);
+  } else if (L2CAP_CONN_PARAM_UPDATE_REQUEST === code) {
+    this.handleConnParamUpdateRequest(data);
+  } else if (L2CAP_CONN_PARAM_UPDATE_RESPONSE === code) {
+    this.handleConnParamUpdateResponse(data);
+  } else if (L2CAP_LE_CONN_REQUEST === code) {
+    this.handleConnectionRequest(data);
+  } else if (L2CAP_LE_CREDITS === code) {
+    this.handleFlowControlCredit(data);
+  } else {
+    debug('unhandled request: ' + code);
+  }
+};
+
+L2cap.prototype.handleCommandRejection = function(req) {
+  var reason = req.readUInt16LE(4);
+  debug('L2CAP Signaling Command Reject: ' + reason);
+};
+
+L2cap.prototype.handleDisconnectRequest = function(req) {
+  var identifier = req.readUInt8(1);
+  var length = req.readUInt16LE(2);
+
+  var reqPacket = req.slice(4);
+  if (reqPacket.length !== length) {
+    debug('request size error!!!');
+    return;
+  }
+
+  var dcid = reqPacket.readUInt16LE(0);
+  var scid = reqPacket.readUInt16LE(2);
+
+  // In our implementation, we expect dcid and scid to be the same.
+  if (dcid !== scid) {
+    debug('Destination CID and Source CID mismatch');
+    this.rejectCommand(identifier, 0x0002, reqPacket);
+    return;
+  }
+
+  var stream = this._activeStreams[scid];
+  if (!stream) {
+    debug('Failed to locate stream');
+    this.rejectCommand(identifier, 0x0002, reqPacket);
+    return;
+  }
+
+  var resp = req;
+  resp[0] = L2CAP_DISCONN_RESPONSE;
+  this.write(resp);
+
+  stream.invalidate();
+  delete this._activeStreams[scid];
+};
+
+L2cap.prototype.handleDisconnectResponse = function(req) {
+  var identifier = req.readUInt8(1);
+  var length = req.readUInt16LE(2);
+
+  var reqPacket = req.slice(4);
+  if (reqPacket.length !== length) {
+    debug('request size error!!!');
+    return;
+  }
+
+  var dcid = reqPacket.readUInt16LE(0);
+  var scid = reqPacket.readUInt16LE(2);
+
+  debug('Disconnect resp:')
+  debug('\tSCID: ' + scid);
+  debug('\tDCID: ' + dcid);
+};
+
+L2cap.prototype.handleConnParamUpdateRequest = function(req) {
+
+};
+
+L2cap.prototype.handleConnParamUpdateResponse = function(req) {
+
+};
+
+L2cap.prototype.handleConnectionRequest = function(req) {
+  debug('LE_CONN request');
+
+  var identifier = req.readUInt8(1);
+  var length = req.readUInt16LE(2);
+
+  var reqPacket = req.slice(4);
+  if (reqPacket.length !== length) {
+    debug('request size error!!!');
+    return;
+  }
+
+  var psm = reqPacket.readUInt16LE(0);
+  var scid = reqPacket.readUInt16LE(2);
+  var mtu = reqPacket.readUInt16LE(4);
+  var mps = reqPacket.readUInt16LE(6);
+  var credits = reqPacket.readUInt16LE(8);
+
+  debug('\tpsm = ' + psm);
+  debug('\tscid = ' + scid);
+  debug('\tmtu = ' + mtu);
+  debug('\tmps = ' + mps);
+  debug('\tcredits = ' + credits);
+
+  var resp = Buffer.alloc(14);
+  resp[0] = L2CAP_LE_CONN_RESPONSE;
+  resp[1] = identifier;
+  
+  // Length
+  resp.writeUInt16LE(0x0A, 2);
+  resp.writeUInt16LE(scid, 4);
+  resp.writeUInt16LE(mtu, 6);
+  resp.writeUInt16LE(mps, 8);
+  resp.writeUInt16LE(credits, 10);
+  resp.writeUInt16LE(0x0000, 12);
+
+  var stream = undefined;
+
+  if (this._registeredPSMs[psm] === undefined) {
+    debug('PSM not registered');
+    resp.writeUInt16LE(0x0002, 12);
+  } else if (scid < L2CAP_CID_DYN_START || scid > L2CAP_CID_DYN_END) {
+    debug('Invalid SCID');
+    resp.writeUInt16LE(0x0009, 12);
+  } else if (this._activeStreams[scid] !== undefined) {
+    debug('SCID already allocated');
+    resp.writeUInt16LE(0x000A, 12);
+  } else {
+    stream = new L2CAPStream(this, psm, scid, mtu, mps, credits);
+    this._activeStreams[scid] = stream;
+  }
+
+  this.write(resp);
+
+  if (stream) {
+    this.emit('newStream', stream);
+  }
+};
+
+L2cap.prototype.handleFlowControlCredit = function(req) {
+  var identifier = req.readUInt8(1);
+  var length = req.readUInt16LE(2);
+
+  var reqPacket = req.slice(4);
+  if (reqPacket.length !== length) {
+    debug('request size error!!!');
+    return;
+  }
+
+  var cid = reqPacket.readUInt16LE(0);
+  var credits = reqPacket.readUInt16LE(2);
+
+  var stream = this._activeStreams[scid];
+  if (stream) {
+    steam._credits = credits;
+  }
+};
+
+L2cap.prototype.rejectCommand = function(id, reason, data) {
+  var resp = Buffer.alloc(6);
+  resp[0] = L2CAP_COMMAND_REJECT;
+  resp[1] = id;
+  resp.writeUInt16LE(reason, 4);
+
+  if (data) {
+    resp = Buffer.concat([
+      resp,
+      data
+    ]);
+    resp.writeUInt16LE(2 + data.length, 2);
+  } else {
+    resp.writeUInt16LE(2, 2);
+  }
+};
+
+L2cap.prototype.write = function(data) {
+  this._aclStream.write(LE_SIGNALING_CID, data);
+};
+
+L2cap.prototype.writeChannelData = function(cid, data) {
+  this._aclStream.write(cid, data);
+};
+
+module.exports = L2cap;

--- a/test-l2cap.js
+++ b/test-l2cap.js
@@ -1,0 +1,100 @@
+var util = require('util');
+
+var bleno = require('./index');
+
+
+var BlenoPrimaryService = bleno.PrimaryService;
+var BlenoCharacteristic = bleno.Characteristic;
+var BlenoDescriptor = bleno.Descriptor;
+
+console.log('bleno');
+
+var StaticReadOnlyCharacteristic = function() {
+  StaticReadOnlyCharacteristic.super_.call(this, {
+    uuid: 'ABDD305628FA441DA47055A75A52553A',
+    properties: ['read'],
+    value: new Buffer('c000', 'hex')
+  });
+};
+util.inherits(StaticReadOnlyCharacteristic, BlenoCharacteristic);
+
+function SampleService() {
+  SampleService.super_.call(this, {
+    uuid: '181E4304CFD346658CC90AA8F18D9298',
+    characteristics: [
+      new StaticReadOnlyCharacteristic()
+    ]
+  });
+}
+
+util.inherits(SampleService, BlenoPrimaryService);
+
+bleno.publishL2CAPChannel(0x00c0, (success, error) => {
+  if (!success) {
+    console.log('Failed to publish channel, error: '+error);
+  } else {
+    console.log('Successfully publish channel');
+  }
+});
+
+bleno.on('l2cap-newStream', (stream) => {
+  console.log('New Stream - psm: ' + stream.psm);
+  stream.on('data', (data)=> {
+    console.log('stream data: ' + data.toString('hex'));
+  })
+
+  stream.on('invalidate', () => {
+    console.log('invalidate stream');
+  })
+
+  var buffer = Buffer.alloc(2048);
+  stream.write(buffer);
+})
+
+bleno.on('stateChange', function(state) {
+  console.log('on -> stateChange: ' + state + ', address = ' + bleno.address);
+
+  if (state === 'poweredOn') {
+    bleno.startAdvertising('test', ['181E4304CFD346658CC90AA8F18D9298']);
+  } else {
+    bleno.stopAdvertising();
+  }
+});
+
+// Linux only events /////////////////
+bleno.on('accept', function(clientAddress) {
+  console.log('on -> accept, client: ' + clientAddress);
+
+  bleno.updateRssi();
+});
+
+bleno.on('disconnect', function(clientAddress) {
+  console.log('on -> disconnect, client: ' + clientAddress);
+});
+
+bleno.on('rssiUpdate', function(rssi) {
+  console.log('on -> rssiUpdate: ' + rssi);
+});
+//////////////////////////////////////
+
+bleno.on('mtuChange', function(mtu) {
+  console.log('on -> mtuChange: ' + mtu);
+});
+
+bleno.on('advertisingStart', function(error) {
+  console.log('on -> advertisingStart: ' + (error ? 'error ' + error : 'success'));
+
+  if (!error) {
+    bleno.setServices([
+      new SampleService()
+    ]);
+  }
+});
+
+bleno.on('advertisingStop', function() {
+  console.log('on -> advertisingStop');
+});
+
+bleno.on('servicesSet', function(error) {
+  console.log('on -> servicesSet: ' + (error ? 'error ' + error : 'success'));
+});


### PR DESCRIPTION
This PR added support for L2CAP LE Credit Based Connection support.
Tested with iOS 11.0b2.

Known Issue:
Requires bleno run with `HCI_CHANNEL_USER` set to true. Otherwise kernel will handle the request event and response PSM not supported.
Didn't actually do credit based flow control.

Usage:
On bleno object, a new method `publishL2CAPChannel` is introduced to allow client register L2CAP channel. A PSM between 0x0080 and 0x00FF is required as per Bluetooth Core Spec 5.0 Vol 3, Part A Section 4.22 Table 4.19. Callback has two parameters, success and error message.

Once BLE central request to establish a connection for published L2CAP channel, bleno will emit event `l2cap-newStream` with the `L2CAPStream` object.

`L2CAPStream` object has a property `psm` which tells which channel the stream belongs to. And when it receives data from central, it will emit `data` event with data buffer. To write data, invoke `L2CAPStream.write()` with data buffer. Finally, when central request to close the channel, an 'invalidate'  event will be emitted.