### PR TITLE
Allow bindings to be injected to Bleno instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 var Bleno = require('./lib/bleno');
+var bindings = require('./lib/resolve-bindings')();
 
-module.exports = new Bleno();
+module.exports = new Bleno(bindings);

--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -1,7 +1,6 @@
 var debug = require('debug')('bleno');
 
 var events = require('events');
-var os = require('os');
 var util = require('util');
 
 var UuidUtil = require('./uuid-util');
@@ -10,19 +9,7 @@ var PrimaryService = require('./primary-service');
 var Characteristic = require('./characteristic');
 var Descriptor = require('./descriptor');
 
-var bindings = null;
-
-var platform = os.platform();
-
-if (platform === 'darwin') {
-  bindings = require('./mac/bindings');
-} else if (platform === 'linux' || platform === 'freebsd' || platform === 'win32' || platform === 'android') {
-  bindings = require('./hci-socket/bindings');
-} else {
-  throw new Error('Unsupported platform');
-}
-
-function Bleno() {
+function Bleno(bindings) {
   this.initialized = false;
   this.platform = 'unknown';
   this.state = 'unknown';

--- a/lib/resolve-bindings.js
+++ b/lib/resolve-bindings.js
@@ -1,0 +1,13 @@
+var os = require('os');
+
+module.exports = function() {
+  var platform = os.platform();
+
+  if (platform === 'darwin') {
+    return require('./mac/bindings');
+  } else if (platform === 'linux' || platform === 'freebsd' || platform === 'win32' || platform === 'android') {
+    return require('./hci-socket/bindings');
+  } else {
+    throw new Error('Unsupported platform');
+  }
+};


### PR DESCRIPTION
Over in [noble](https://github.com/noble/noble) we can inject bindings into the `Noble` instance ([commit](https://github.com/noble/noble/commit/c1e7a065f24fa0530bde41a1efab8b4917eb2965)), so we should do the same here too.

The end goal is to create native bindings (wip over at https://github.com/notjosh/bleno-mac).