### PR TITLE
use xpc-connect

### DIFF
--- a/lib/mac/highsierra.js
+++ b/lib/mac/highsierra.js
@@ -7,7 +7,7 @@ var events = require('events');
 var os = require('os');
 var util = require('util');
 
-var XpcConnection = require('xpc-connection');
+var XpcConnection = require('xpc-connect');
 
 var uuidToAddress = require('./uuid-to-address');
 

--- a/lib/mac/yosemite.js
+++ b/lib/mac/yosemite.js
@@ -7,7 +7,7 @@ var events = require('events');
 var os = require('os');
 var util = require('util');
 
-var XpcConnection = require('xpc-connection');
+var XpcConnection = require('xpc-connect');
 
 var uuidToAddress = require('./uuid-to-address');
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   "optionalDependencies": {
     "bluetooth-hci-socket": "^0.5.1",
     "bplist-parser": "0.0.6",
-    "xpc-connection": "~0.1.4"
+    "xpc-connect": "^1.1.2"
   }
 }


### PR DESCRIPTION
[xpc-connection](https://www.npmjs.com/package/xpc-connection) does not appear to be maintained anymore. Might I suggest you give [xpc-connect](https://www.npmjs.com/package/xpc-connect) a try which is a fork with added support for Mojave