### PR TITLE
Increase max MTU size to 512 bytes

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -64,7 +64,7 @@ var ATT_ECODE_INSUFF_RESOURCES      = 0x11;
 var ATT_CID = 0x0004;
 
 var Gatt = function() {
-  this.maxMtu = 256;
+  this.maxMtu = 512;
   this._mtu = 23;
   this._preparedWriteRequest = null;
 


### PR DESCRIPTION
In the Bluetooth Core Specification 4.0, the maximum MTU can be configured to up to 512 bytes. "The maximum length of an attribute value shall be 512 octets." (page 1839, 3.2.9 Long Attribute Values)