### PR TITLE
Update bindings to support MacOS Catalina

### DIFF
--- a/lib/mac/bindings.js
+++ b/lib/mac/bindings.js
@@ -1,7 +1,7 @@
 var os = require('os');
 var osRelease = parseFloat(os.release());
 
-if (osRelease < 17 ) {
+if (osRelease < 17 || osRelease > 18 ) {
   module.exports = require('./yosemite');
 } else {
   module.exports = require('./highsierra');


### PR DESCRIPTION
In the new release of Catalina it appears the message ids from the xpc events have been remapped back to Yosemite.

This change will check if the release version is above 18, if so yosemite bindings will be used instead of highsierra.